### PR TITLE
Répare le nom des setters dans \Repositories\Rooms::pull

### DIFF
--- a/website/Repositories/Rooms.php
+++ b/website/Repositories/Rooms.php
@@ -110,8 +110,8 @@ class Rooms extends Repository
 
         // Store
         $arr = array(
-            "setId" => $data["id"],
-            "setPropertyId" => $data["property_id"],
+            "setID" => $data["id"],
+            "setPropertyID" => $data["property_id"],
             "setCreationDate" => $data["creation_date"],
             "setLastUpdated" => $data["last_updated"],
         );


### PR DESCRIPTION
Une mise à jour précédente avait modifié les noms sans pour autant modifier cette méthode.