### PR TITLE
Répare un bug de chargement de classes inexistantes dans le Handler

### DIFF
--- a/website/Helpers/Handler.php
+++ b/website/Helpers/Handler.php
@@ -66,6 +66,11 @@ class Handler
         // Get the fully qualified name of the class
         $classname = "\\Controllers\\" . $category;
 
+        // Check that the class file exists
+        if (!classFileExists($classname)) {
+            return null;
+        }
+
         // Check that the class exists
         // doc: https://secure.php.net/manual/fr/function.class-exists.php
         if (!class_exists($classname)) {

--- a/website/Helpers/autoloader.php
+++ b/website/Helpers/autoloader.php
@@ -9,14 +9,26 @@
  * Charge une classe en utilisant son Namespace comme structure de dossier
  *
  * @param string $classname
- * @throws Exception
+ * @throws \Exception
  */
 function __autoload(string $classname)
 {
-    $path = str_replace('\\', DIRECTORY_SEPARATOR, $classname) . '.php';
-    $path = str_replace('/',DIRECTORY_SEPARATOR,__DIR__ . '/../' . $path);
+    $path = classToPath($classname);
     if (!file_exists($path)) {
-        throw new Exception("File does not exist : $path");
+        throw new \Exception("File does not exist : $path");
     }
     require_once($path);
+}
+
+function classFileExists(string $classname): bool
+{
+    $path = classToPath($classname);
+    return file_exists($path);
+}
+
+function classToPath(string $classname): string
+{
+    $path = str_replace('\\', DIRECTORY_SEPARATOR, $classname) . '.php';
+    $path = str_replace('/', DIRECTORY_SEPARATOR, __DIR__ . '/../' . $path);
+    return $path;
 }


### PR DESCRIPTION
Répare un *bug* causé par la non-vérification de l'éxistence de la classe contrôleur dans le Handler, menant à un crash lors d'une indication invalide de la catégorie du contrôleur dans le Handler.