### PR TITLE
Améliore les exceptions de la méthode \Entities\Entity::setMultiple

### DIFF
--- a/website/Entities/Entity.php
+++ b/website/Entities/Entity.php
@@ -48,12 +48,12 @@ abstract class Entity
 
     /**
      * @param array $order property_name => data
-     * @param bool $must_set if set to true, will throw an exception instead of returning "false"
      *
      * @return bool
      * @throws \Exception
      */
-    public function setMultiple(array $order, bool $must_set = false): bool {
+    public function setMultiple(array $order): bool
+    {
         // Loop over properties to get the mapping
         foreach ($order as $property_name => $data) {
             // Get the setter name
@@ -61,14 +61,37 @@ abstract class Entity
 
             // Check if it exists
             if (!method_exists($this, $setter_name)) {
-                throw new UnknownSetterException($this,$setter_name);
+                throw new UnknownSetterException($this, $setter_name);
             }
 
-            // Get its type
-            $reflection_method = new \ReflectionMethod($this, $setter_name);
+            // Récupération de l'objet de reflection de la méthode
+            try {
+                $reflection_method = new \ReflectionMethod($this, $setter_name);
+            } catch (\ReflectionException $re) {
+                throw new \Exception(
+                    sprintf("Erreur lors de la récupération de l'objet de réflection de la méthode %s::%s", static::class, $setter_name),
+                    0,
+                    $re);
+            }
+
+            // Récupération des paramètres
             $reflection_parameters = $reflection_method->getParameters();
+
+            // S'il n'y a pas exactement 1 paramètre, erreur
+            if (count($reflection_parameters) !== 1) {
+                throw new \Exception(sprintf("Erreur: nombre de paramètres différent de 1 pour la méthode %s::%s", static::class, $setter_name));
+            }
+
+            // Récuperer le paramètre
             $reflection_parameter = $reflection_parameters[0];
+
+            // Récuperer le type du paramètre
             $reflection_parameter_type = $reflection_parameter->getType();
+            if ($reflection_parameter_type === null) {
+                throw new \Exception(sprintf("Erreur: pas de type spécifié pour le paramètre de la méthode %s::%s", static::class, $setter_name));
+            }
+
+            // Switcher dessus pour convertir les données si nécéssaire
             switch ($reflection_parameter_type->getName()) {
                 case "string":
                     $data = (string)$data;
@@ -81,10 +104,7 @@ abstract class Entity
             // Apply it
             $success = $this->$setter_name($data);
             if ($success === false) {
-                if ($must_set) {
-                    throw new SetFailedException($this,$setter_name,$data);
-                }
-                return false;
+                throw new SetFailedException($this, $setter_name, $data);
             }
         }
 


### PR DESCRIPTION
De plus:
- Documente le code
- Rend tout échec fatal via une exception documentée
- Remplace les exceptions d'origine par des indications plus claires (plus de "getName on NULL"
- Supprime le deuxième paramètre devenu initule voire nocif