### PR TITLE
Répare le problème d'encodage de caractères avec les requêtes SQL.

### DIFF
--- a/website/Helpers/DB.php
+++ b/website/Helpers/DB.php
@@ -46,7 +46,7 @@ class DB
     {
         if (!isset(self::$instance)) {
             $pdo_options[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
-            $dsn = 'mysql:host=' . self::HOST . ';dbname=' . self::DBNAME;
+            $dsn = 'mysql:host=' . self::HOST . ';dbname=' . self::DBNAME . ';charset=UTF8';
             self::$instance = new PDO($dsn, self::USERNAME, self::PASSWORD, $pdo_options);
         }
         return self::$instance;


### PR DESCRIPTION
Le problème était dans l'absence de paramètre `charset` dans le DSN pour la création de la connection avec la BDD via PDO.